### PR TITLE
chore: improve RCBot types

### DIFF
--- a/src/rc-bot.ts
+++ b/src/rc-bot.ts
@@ -20,8 +20,8 @@ type RCBotConfig = {
 export default class RCBot {
   constructor(
     private config: RCBotConfig,
-    private githubService: GithubService,
-    private slackBotService: SlackBotService
+    private githubService: InstanceType<typeof GithubService>,
+    private slackBotService: InstanceType<typeof SlackBotService>
   ) {
     this.config = {
       ...config,


### PR DESCRIPTION
It will allow to pass any objects that will match githubService and slackBotService interface.
It can be helpful during testing.
It is just an experiment, but let see how it will be useful.